### PR TITLE
add bots, change log likelihood, add tests, remove some dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,46 @@
+name: CI
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+    tags: '*'
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.6' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
+          - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
+          #- 'nightly'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,16 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,15 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -6,15 +6,17 @@ version = "0.1.0"
 [deps]
 ConcreteStructs = "2569d6c7-a4a2-43d3-a901-331e8e4be471"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-DifferentialEvolutionMCMC = "607db5a9-722a-4af8-9a06-1810c0fe385b"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
-Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 
 [compat]
+ConcreteStructs = "0.2.0"
+DataFrames = "1.3.0"
+Distributions = "0.25.0"
+SafeTestsets = "0.0.1"
+StatsBase = "0.33.0"
 julia = "1"
 
 [extras]

--- a/model/example.jl
+++ b/model/example.jl
@@ -12,7 +12,7 @@ using DifferentialEvolutionMCMC
 ###############################################################################################
 #                                         Example Data                                        #
 ###############################################################################################
-ex_params = (n_subs = 1, n_features = 10, n_trials = 400, relatedness = 0.25, decay = 0.65)
+ex_params = (n_subs = 1, n_features = 10, n_trials = 40, relatedness = 0.25, decay = 0.65)
 ex_model = MHG(;ex_params...)
 ex_outcome = cued_recall(ex_model, 0.5)
 ex_corr = sum(ex_outcome.Outcome .== :Correct)

--- a/model/example.jl
+++ b/model/example.jl
@@ -8,11 +8,11 @@ using Pkg
 Pkg.activate("..")
 using MetaHyGene, Random, Distributions, Plots, StatsPlots, StatsBase, DataFrames
 using DifferentialEvolutionMCMC
-Random.seed!(8197)
+#Random.seed!(8197)
 ###############################################################################################
 #                                         Example Data                                        #
 ###############################################################################################
-ex_params = (n_subs = 10, n_features = 10, n_trials = 40, relatedness = 0.25, decay = 0.65)
+ex_params = (n_subs = 1, n_features = 10, n_trials = 40, relatedness = 0.25, decay = 0.65)
 ex_model = MHG(;ex_params...)
 ex_outcome = cued_recall(ex_model, 0.5)
 ex_corr = sum(ex_outcome.Outcome .== :Correct)

--- a/model/example.jl
+++ b/model/example.jl
@@ -12,7 +12,7 @@ using DifferentialEvolutionMCMC
 ###############################################################################################
 #                                         Example Data                                        #
 ###############################################################################################
-ex_params = (n_subs = 1, n_features = 10, n_trials = 40, relatedness = 0.25, decay = 0.65)
+ex_params = (n_subs = 1, n_features = 10, n_trials = 400, relatedness = 0.25, decay = 0.65)
 ex_model = MHG(;ex_params...)
 ex_outcome = cued_recall(ex_model, 0.5)
 ex_corr = sum(ex_outcome.Outcome .== :Correct)

--- a/src/MetaHyGene.jl
+++ b/src/MetaHyGene.jl
@@ -1,14 +1,14 @@
 module MetaHyGene
 
-using Distributions, DataFrames, Plots, StatsPlots, Turing, StatsBase, DifferentialEvolutionMCMC, ConcreteStructs, Random
+    using Distributions, DataFrames, StatsBase, ConcreteStructs, Random
 
-export cued_recall, recall_trial
-include("main.jl")
+    export cued_recall, recall_trial
+    include("main.jl")
 
-export sim_controller, sim_replicator, trace_replicator, sim_calc, act_calc, echo_intensity, echo_content, recall_summary, block_header, line_header
-include("utils.jl")
+    export sim_controller, sim_replicator, trace_replicator, sim_calc, act_calc, echo_intensity, echo_content, recall_summary, block_header, line_header
+    include("utils.jl")
 
-export AbstractMHG, MHG, Memory
-include("structs.jl")
+    export AbstractMHG, MHG, Memory
+    include("structs.jl")
 
 end

--- a/src/main.jl
+++ b/src/main.jl
@@ -17,11 +17,13 @@ function cued_recall(model, threshold::Float64)
                          Target = Int64[],
                          RESP = Int64[],
                          Outcome = Symbol[])
+    # I don't think you need to differentiate between subjects and trials if iid 
     for sub in 1:model.n_subs
-        trial_list = shuffle(collect(1:model.n_trials))
+        trial_list = shuffle!([1:model.n_trials;])
         for i in 1:model.n_trials
             probe = model.cues[trial_list[i],:]
-            probe = vcat(probe,zeros(length(probe)))
+            # I recommend adding zeros to the probe upon initializing the model 
+            probe = vcat(probe, zeros(length(probe)))
             echo_int, resp, outcome = recall_trial(probe, model.cues, model.targets, threshold, trial_list[i])
             push!(out_data, [sub, i, echo_int, trial_list[i], resp, outcome])
         end

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -1,15 +1,49 @@
 abstract type AbstractMHG end
 
-@concrete mutable struct MHG{Int64,Float64,Matrix} <: AbstractMHG
-    n_subs::Int64
-    n_features::Int64
-    n_trials::Int64
-    relatedness::Float64
-    decay::Float64
-    cues::Matrix
-    targets::Matrix
+"""
+    MHG <: AbstractMHG
+
+An object representing a MetaHyGene model.
+
+# Fields 
+
+- `n_subs`: the number of subjects in the simulation 
+- `n_features`: the number of features in a memory trace 
+- `n_trials`: the number of trials in the simulated experiment 
+- `relatedness`: the degree of relatedness between memory traces 
+- `decay`: decay in memory activation 
+- `cues`: a vector of cues, one for each trial 
+- `targets`: a vector of targets, one for each trial 
+"""
+@concrete mutable struct MHG <: AbstractMHG
+    n_subs
+    n_features
+    n_trials
+    relatedness
+    decay
+    cues
+    targets
 end
 
+"""
+    MHG(;
+        n_subs::Int64,
+        n_features::Int64,
+        n_trials::Int64,
+        relatedness::Float64,
+        decay::Float64
+    )
+
+An constructor for a MetaHyGene model which generates cues and targets. 
+
+# Keywords 
+
+- `n_subs`: the number of subjects in the simulation 
+- `n_features`: the number of features in a memory trace 
+- `n_trials`: the number of trials in the simulated experiment 
+- `relatedness`: the degree of relatedness between memory traces 
+- `decay`: decay in memory activation 
+"""
 function MHG(;
     n_subs::Int64,
     n_features::Int64,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -9,19 +9,19 @@ Creates vectors of integers [-1,0,1] with probability [0.4,0.2,0.4].
   - `relatedness::Float64`: Probability of replacing current integer with random choice from [-1,0,1].
 
 """
-sim_controller(n_features::Int64) = sample([-1,0,1],Weights([0.4,0.2,0.4]), n_features)
+sim_controller(n_features::Int64) = sample([-1,0,1], Weights([0.4,0.2,0.4]), n_features)
 
-sim_controller(n_features::Int64, n_trials::Int64) = sample([-1,0,1],Weights([0.4,0.2,0.4]), (n_trials,n_features))
+sim_controller(n_features::Int64, n_trials::Int64) = sample([-1,0,1], Weights([0.4,0.2,0.4]), (n_trials,n_features))
 
 function sim_controller(n_features::Int64, relatedness::Float64)
-    a = sample([-1,0,1],Weights([0.4,0.2,0.4]), n_features)
-    b = sim_replicator(a,relatedness)
+    a = sample([-1,0,1], Weights([0.4,0.2,0.4]), n_features)
+    b = sim_replicator(a, relatedness)
     return a,b
 end
 
 function sim_controller(n_features::Int64, n_trials::Int64, relatedness::Float64)
     a = sample([-1,0,1],Weights([0.4,0.2,0.4]), (n_trials,n_features))
-    b = sim_replicator(a,relatedness)
+    b = sim_replicator(a, relatedness)
     return a,b
 end
 
@@ -33,7 +33,7 @@ end
 function sim_replicator(probe::Vector{Int64}, relatedness::Float64)
     out_vec = copy(probe)
     for i in 1:length(probe)
-        if rand(Uniform()) > relatedness
+        if rand() > relatedness
             out_vec[i] = sample([-1,0,1],Weights([0.4,0.2,0.4]))
         end
     end
@@ -42,11 +42,9 @@ end
 
 function sim_replicator(probe::Matrix{Int64}, relatedness::Float64)
     out_vec = copy(probe)
-    for i in size(probe,1)
-        for j in size(probe,2)
-            if rand(Uniform()) > relatedness
-                out_vec[i,j] = sample([-1,0,1],Weights([0.4,0.2,0.4]))
-            end
+    for i in 1:length(probe)
+        if rand() > relatedness
+            out_vec[i] = sample([-1,0,1], Weights([0.4,0.2,0.4]))
         end
     end
     return out_vec
@@ -66,7 +64,7 @@ Replaces integers in probe array with 0 with probability `decay`.
 function trace_replicator(probe::Vector{Int64}, decay::Float64)
     out_vec = copy(probe)
     for i in 1:length(probe)
-        rand(Uniform()) < decay ? out_vec[i] = 0 : nothing
+        rand() < decay ? out_vec[i] = 0 : nothing
     end
     return out_vec
 end
@@ -74,9 +72,7 @@ end
 function trace_replicator(probe::Matrix{Int64}, decay::Float64)
     out_vec = copy(probe)
     for i in 1:size(probe,1)
-        for j in 1:size(probe,2)
-            rand(Uniform()) < decay ? out_vec[i,j] = 0 : nothing
-        end
+        rand() < decay ? out_vec[i] = 0 : nothing
     end
     return out_vec
 end
@@ -85,18 +81,19 @@ end
     sim_calc()
 
 """
-function sim_calc(probe::Vector, referent::Vector)
+function sim_calc(probe::Vector, referent)
     base = 0.0; count = length(probe)
     for i in 1:length(probe)
         (probe[i] == 0) && (referent[i] == 0) ? count -= 1 : base += (probe[i] * referent[i])
     end
-    return base/count
+    return base / count
 end
 
 function sim_calc(probe::Vector, referent::Matrix)
-    sims = []
-    for i in 1:size(referent,1)
-        push!(sims,sim_calc(probe,referent[i,:]))
+    n = size(referent, 1)
+    sims = fill(0.0, n)
+    for i in 1:n
+        sims[i] = sim_calc(probe, @view referent[i,:])
     end
     return sims
 end
@@ -106,9 +103,9 @@ end
     act_calc()
 
 """
-act_calc(probe::Vector, referent::Vector) = sim_calc(probe,referent)^3
+act_calc(probe::Vector, referent) = sim_calc(probe, referent)^3
 
-act_calc(probe::Vector, referent::Matrix) = sim_calc(probe,referent).^3
+act_calc(probe::Vector, referent::Matrix) = sim_calc(probe, referent).^3
 
 
 """
@@ -124,7 +121,7 @@ end
     echo_intensity()
 
 """
-echo_intensity(probe::Vector, referent::Matrix) = sum(act_calc(probe,referent))
+echo_intensity(probe::Vector, referent::Matrix) = sum(act_calc(probe, referent))
 
 
 """
@@ -134,7 +131,7 @@ echo_intensity(probe::Vector, referent::Matrix) = sum(act_calc(probe,referent))
 function echo_content(probe::Vector, referent::Matrix, normalize=true)
     out_vec = zeros(size(probe))
     for i in 1:size(referent,1)
-        out_vec .+= (act_calc(probe,referent[i,:]).*referent[i,:])
+        out_vec .+= (act_calc(probe, @view referent[i,:]).* @view referent[i,:])
     end
     normalize ? (return out_vec ./ maximum(out_vec)) : (return out_vec)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -20,7 +20,7 @@ function sim_controller(n_features::Int64, relatedness::Float64)
 end
 
 function sim_controller(n_features::Int64, n_trials::Int64, relatedness::Float64)
-    a = sample([-1,0,1],Weights([0.4,0.2,0.4]), (n_trials,n_features))
+    a = sample([-1,0,1], Weights([0.4,0.2,0.4]), (n_trials,n_features))
     b = sim_replicator(a, relatedness)
     return a,b
 end
@@ -62,7 +62,7 @@ Replaces integers in probe array with 0 with probability `decay`.
 
 """
 function trace_replicator(probe::Vector{Int64}, decay::Float64)
-    out_vec = copy(probe)
+    out_vec = deepcopy(probe)
     for i in 1:length(probe)
         rand() < decay ? out_vec[i] = 0 : nothing
     end
@@ -70,8 +70,8 @@ function trace_replicator(probe::Vector{Int64}, decay::Float64)
 end
 
 function trace_replicator(probe::Matrix{Int64}, decay::Float64)
-    out_vec = copy(probe)
-    for i in 1:size(probe,1)
+    out_vec = deepcopy(probe)
+    for i in 1:length(probe)
         rand() < decay ? out_vec[i] = 0 : nothing
     end
     return out_vec
@@ -86,7 +86,7 @@ function sim_calc(probe::Vector, referent)
     for i in 1:length(probe)
         (probe[i] == 0) && (referent[i] == 0) ? count -= 1 : base += (probe[i] * referent[i])
     end
-    return base / count
+    return base/count
 end
 
 function sim_calc(probe::Vector, referent::Matrix)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -30,17 +30,7 @@ end
 
 
 """
-function sim_replicator(probe::Vector{Int64}, relatedness::Float64)
-    out_vec = copy(probe)
-    for i in 1:length(probe)
-        if rand() > relatedness
-            out_vec[i] = sample([-1,0,1],Weights([0.4,0.2,0.4]))
-        end
-    end
-    return out_vec
-end
-
-function sim_replicator(probe::Matrix{Int64}, relatedness::Float64)
+function sim_replicator(probe, relatedness::Float64)
     out_vec = copy(probe)
     for i in 1:length(probe)
         if rand() > relatedness
@@ -61,16 +51,8 @@ Replaces integers in probe array with 0 with probability `decay`.
   - `decay::Float64`: Rate of decay between 0.0 and 1.0, with 1.0 being complete decay.
 
 """
-function trace_replicator(probe::Vector{Int64}, decay::Float64)
-    out_vec = deepcopy(probe)
-    for i in 1:length(probe)
-        rand() < decay ? out_vec[i] = 0 : nothing
-    end
-    return out_vec
-end
-
-function trace_replicator(probe::Matrix{Int64}, decay::Float64)
-    out_vec = deepcopy(probe)
+function trace_replicator(probe, decay::Float64)
+    out_vec = copy(probe)
     for i in 1:length(probe)
         rand() < decay ? out_vec[i] = 0 : nothing
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,11 +22,11 @@ end
     # expected probability an element is zero
     p_zero = p + (1 - p) * .2
     est_p_zero = mean(x .== 0)
-    @test p_zero ≈ est_p_zero atol = 1e-3
+    @test p_zero ≈ est_p_zero atol = 5e-2
     est_p_one = mean(x .== 1)
-    @test (1 - p_zero) / 2 ≈ est_p_one atol = 1e-3
+    @test (1 - p_zero) / 2 ≈ est_p_one atol = 5e-2
     est_p_neg_one = mean(x .== -1)
-    @test (1 - p_zero) / 2 ≈ est_p_neg_one atol = 1e-3
+    @test (1 - p_zero) / 2 ≈ est_p_neg_one atol = 5e-2
 
 
     p = .1
@@ -34,21 +34,20 @@ end
     # expected probability an element is zero
     p_zero = p + (1 - p) * .2
     est_p_zero = mean(x .== 0)
-    @test p_zero ≈ est_p_zero atol = 1e-3
+    @test p_zero ≈ est_p_zero atol = 5e-2
     est_p_one = mean(x .== 1)
-    @test (1 - p_zero) / 2 ≈ est_p_one atol = 1e-3
+    @test (1 - p_zero) / 2 ≈ est_p_one atol = 5e-2
     est_p_neg_one = mean(x .== -1)
-    @test (1 - p_zero) / 2 ≈ est_p_neg_one atol = 1e-3
+    @test (1 - p_zero) / 2 ≈ est_p_neg_one atol = 5e-2
 
     p = .9
     x = sim_replicator(probe, p)
     # expected probability an element is zero
     p_zero = p + (1 - p) * .2
     est_p_zero = mean(x .== 0)
-    @test p_zero ≈ est_p_zero atol = 1e-3
+    @test p_zero ≈ est_p_zero atol = 5e-2
     est_p_one = mean(x .== 1)
-    @test (1 - p_zero) / 2 ≈ est_p_one atol = 1e-3
+    @test (1 - p_zero) / 2 ≈ est_p_one atol = 5e-2
     est_p_neg_one = mean(x .== -1)
-    @test (1 - p_zero) / 2 ≈ est_p_neg_one atol = 1e-3
+    @test (1 - p_zero) / 2 ≈ est_p_neg_one atol = 5e-2
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,14 +11,44 @@ using SafeTestsets
     @test size(model.targets) == (model.n_trials,model.n_features)
 end
 
-@safetestset "model constructor" begin
+@safetestset "sim_replicator" begin
     using MetaHyGene
-    using Test
-    ex_params = (n_subs = 1, n_features = 10, n_trials = 40, relatedness = 0.25, decay = 0.65)
-    model = MHG(;ex_params...)
+    using Test, Random, Statistics 
+    Random.seed!(845)
 
-    @test model.n_subs == ex_params.n_subs
-    @test size(model.cues) == (model.n_trials,model.n_features)
-    @test size(model.targets) == (model.n_trials,model.n_features)
+    probe = fill(0, 500, 500)
+    p = .4
+    x = sim_replicator(probe, p)
+    # expected probability an element is zero
+    p_zero = p + (1 - p) * .2
+    est_p_zero = mean(x .== 0)
+    @test p_zero ≈ est_p_zero atol = 1e-3
+    est_p_one = mean(x .== 1)
+    @test (1 - p_zero) / 2 ≈ est_p_one atol = 1e-3
+    est_p_neg_one = mean(x .== -1)
+    @test (1 - p_zero) / 2 ≈ est_p_neg_one atol = 1e-3
+
+
+    p = .1
+    x = sim_replicator(probe, p)
+    # expected probability an element is zero
+    p_zero = p + (1 - p) * .2
+    est_p_zero = mean(x .== 0)
+    @test p_zero ≈ est_p_zero atol = 1e-3
+    est_p_one = mean(x .== 1)
+    @test (1 - p_zero) / 2 ≈ est_p_one atol = 1e-3
+    est_p_neg_one = mean(x .== -1)
+    @test (1 - p_zero) / 2 ≈ est_p_neg_one atol = 1e-3
+
+    p = .9
+    x = sim_replicator(probe, p)
+    # expected probability an element is zero
+    p_zero = p + (1 - p) * .2
+    est_p_zero = mean(x .== 0)
+    @test p_zero ≈ est_p_zero atol = 1e-3
+    est_p_one = mean(x .== 1)
+    @test (1 - p_zero) / 2 ≈ est_p_one atol = 1e-3
+    est_p_neg_one = mean(x .== -1)
+    @test (1 - p_zero) / 2 ≈ est_p_neg_one atol = 1e-3
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,12 @@
-using MetaHyGene
-using Test
+using SafeTestsets
 
-@testset "MetaHyGene.jl" begin
-    # Write your tests here.
+@safetestset "model constructor" begin
+    using MetaHyGene
+    using Test
+    ex_params = (n_subs = 1, n_features = 10, n_trials = 40, relatedness = 0.25, decay = 0.65)
+    model = MHG(;ex_params...)
+
+    @test model.n_subs == ex_params.n_subs
+    @test size(model.cues) == (model.n_trials,model.n_features)
+    @test size(model.targets) == (model.n_trials,model.n_features)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,3 +10,15 @@ using SafeTestsets
     @test size(model.cues) == (model.n_trials,model.n_features)
     @test size(model.targets) == (model.n_trials,model.n_features)
 end
+
+@safetestset "model constructor" begin
+    using MetaHyGene
+    using Test
+    ex_params = (n_subs = 1, n_features = 10, n_trials = 40, relatedness = 0.25, decay = 0.65)
+    model = MHG(;ex_params...)
+
+    @test model.n_subs == ex_params.n_subs
+    @test size(model.cues) == (model.n_trials,model.n_features)
+    @test size(model.targets) == (model.n_trials,model.n_features)
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,3 +51,16 @@ end
     est_p_neg_one = mean(x .== -1)
     @test (1 - p_zero) / 2 ≈ est_p_neg_one atol = 5e-2
 end
+
+
+@safetestset "trace_replicator" begin
+    using MetaHyGene
+    using Test, Random, Statistics 
+    Random.seed!(665)
+
+    probe = fill(1, 500, 500)
+    d = .4
+    x = trace_replicator(probe, d)
+
+    @test mean(x .== 0) ≈ d atol = 5e-2
+end


### PR DESCRIPTION
This looks really interesting. I would like to learn more at some point. I made some suggested changes that might help with maintaining the package and workflow. In addition, I suggested a few changes to the log likelihood function in your example. Here is a summary:

-  no need to specify types with @concrete, but you can opt in 

-  pass sim_params to the log likelihood function so you can change them without changing the function 

-  i think the likelihood function is a Multinomial

-  I don't think the fit normal was contributing to your log likelihood, you might consider sampling μ and σ through DEMCMC 

-  added SafeTestsets with a simple test 

-  added CI for unit tests 

 - added compat helper and tagbot
 
 - I'm not sure if 40 trials will give you stable results
 
 - if your predictions are changing each trial, you might want to compute the log likelihood 
 of each trial to fully leverage the data to estimate decay. For example, you might want to return an 
 n_sim X n_trial matrix and compute your Multinomial log likelihood across n_sim where n_sim is 
somewhat large 

- I added compatibility constraints to Project.toml

- I removed Turing DEMCMC, StatsPlots and Plots because the convention is to reduce unnecessary 
dependencies. In this case it is important because Turing and Plots are large dependencies. Most 
developers work in a "sandbox" package where you can add Turing and Plots to a temporary environment 
